### PR TITLE
extract wiki urls (tests and code)

### DIFF
--- a/scraper/schema.py
+++ b/scraper/schema.py
@@ -11,12 +11,14 @@ columns_with_synonyms = {
                   'Anmerkungen',
                   'Bemerkungen',
                   ],
+    'Bild' : ['Foto'],
+    'Wikipedia-URL' : []
 }
 
 
 # Automatically generate schema and synonym map for scraper (dev only)
 
-schema = [column for column in columns_with_synonyms.keys()]
+schema = list(columns_with_synonyms.keys())
 
 schema_map = {}
 

--- a/scraper/wiki_fetcher.py
+++ b/scraper/wiki_fetcher.py
@@ -5,13 +5,17 @@ import logging
 import os
 from datetime import datetime
 
+import requests
 import pandas as pd
+import bs4 as bs
 
 from .schema import schema, schema_map
 from .urls import parliaments
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(message)s')
 
+WIKI_BASE_URL = "https://de.wikipedia.org"
+columns_for_link_extraction = ['Name', 'Mitglied des Landtages', 'Bild', 'Foto']
 
 class WikiFetcher:
     """
@@ -21,31 +25,63 @@ class WikiFetcher:
     def __init__(self):
         pass
 
+    def parse_table(self, parsed_table):
+        header = [th.text.strip() for th in parsed_table.find_all('th')]
+        data = []
+        for row in parsed_table.find_all('tr'):
+            # clean for hidden data
+            for tag in row.select( '[style~="display:none"]'):
+                tag.decompose()
+            # skip headeer
+            if not row.find('td'):
+                continue
+            # iterate over cells
+            item = []
+            for col_i, td in enumerate(row.find_all('td')):
+                text = td.text.strip()
+                if header[col_i] in columns_for_link_extraction:
+                    # add link, if there is any
+                    if td.find('a'):
+                        if text:
+                            text += '|'
+                        link = WIKI_BASE_URL + td.a['href']
+                    else:
+                        link = ''
+                    text += link
+                item.append(text)
+            data.append(item)
+        df = pd.DataFrame(data, columns=header)
+        return df
+
     def get_politicians(self, wiki_url):
+        req = requests.get(wiki_url)
+        html_source = req.content
+        soup = bs.BeautifulSoup(html_source, 'lxml')
         # read html tables from url
-        html_tables = pd.read_html(wiki_url)
+        html_tables = soup.find_all('table')
         # heuristic: assume largest table to contain all parlamentarians
-        html_tables_lengths = [len(table.index) for table in html_tables]
-        politicians_table_index = html_tables_lengths.index(
-            max(html_tables_lengths))
-        politicians_table = html_tables[politicians_table_index]
+        rows_per_table = [len(t.find_all('tr')) for t in html_tables]
+        politicians_table_index = rows_per_table.index(max(rows_per_table))
+        largest_table = html_tables[politicians_table_index]
+        # extract data
+        politicians_table = self.parse_table(largest_table)
+        # unify schema
         politicians_table = self.clean_table(politicians_table, schema, url=wiki_url)
         # return table and table index for logging purposes
         return politicians_table, politicians_table_index
 
     def clean_table(self, table, schema_list, url=''):
-
         for column_name in schema_map:
             table.rename(
                 columns={column_name: schema_map[column_name]},
                 inplace=True
             )
-
         try:
+            # split Name into Name and Wikipedia-URL
+            table[['Name', 'Wikipedia-URL']] = table['Name'].str.split("|", expand=True)
             table = table[schema_list]
         except KeyError:
             raise KeyError(f"{schema_list} for {url} not in {table.columns.values}. Edit schema.py.")
-
         return table
 
     def fetch_all_parliaments(self):


### PR DESCRIPTION
Tests and code for #18 

pandas is no longer used for html table extraction since the parsing of URLs from tables required a more specific table parser. This is now realized with bs4.